### PR TITLE
Create agent configuration directory if missing

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -7,6 +7,14 @@ module RackspaceCloudMonitoringCookbook
       '/etc/rackspace-monitoring-agent.conf.d'
     end
 
+    def create_agent_conf_d
+      directory agent_conf_d do
+        owner 'root'
+        group 'root'
+        mode 00755
+      end
+    end
+
     def plugin_path
       '/usr/lib/rackspace-monitoring-agent/plugins'
     end

--- a/libraries/provider_rackspace_cloud_monitoring_check.rb
+++ b/libraries/provider_rackspace_cloud_monitoring_check.rb
@@ -39,6 +39,9 @@ class Chef
       end
 
       def generate_agent_config(disabled = false, targets = nil)
+        # in case the agent directory is missing
+        create_agent_conf_d
+
         if targets && !targets.empty?
           targets.each do |target|
             sanitized_target = sanitize_target(target, new_resource.type)

--- a/libraries/provider_rackspace_cloud_monitoring_service.rb
+++ b/libraries/provider_rackspace_cloud_monitoring_service.rb
@@ -30,11 +30,7 @@ class Chef
         end
 
         # Set directory to put agent configuration
-        directory agent_conf_d do
-          owner 'root'
-          group 'root'
-          mode 00755
-        end
+        create_agent_conf_d
         service_enable
       end
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -5,7 +5,7 @@ maintainer_email 'rackspace-cookbooks@rackspace.com'
 license 'Apache 2.0'
 description 'Installs/Configures rackspace_cloud_monitoring'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '0.0.2'
+version '0.0.3'
 
 depends 'apt'
 depends 'yum'

--- a/test/unit/spec/rackspace_cloud_monitoring_check_shared.rb
+++ b/test/unit/spec/rackspace_cloud_monitoring_check_shared.rb
@@ -1,5 +1,8 @@
 shared_examples_for 'agent config' do |agent, filename|
   filename = agent unless filename
+  it 'creates agent configuration directory' do
+    expect(chef_run).to create_directory('/etc/rackspace-monitoring-agent.conf.d')
+  end
   it 'calls rackspace_cloud_monitoring_check resource' do
     expect(chef_run).to create_rackspace_cloud_monitoring_check(agent)
   end


### PR DESCRIPTION
I will allow to use rackspace_cloud_monitoring_check even if you've not called rackspace_cloud_monitoring_service
