### PR TITLE
Fixed behavior on auto-target without alarm

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -109,7 +109,7 @@ module RackspaceCloudMonitoringCookbook
       case new_resource.type
       # Disable alarm for agent_disk if not target was specified
       when 'agent.disk'
-        return false if new_resource.target && ! new_resource.alarm_criteria
+        return false unless new_resource.alarm_criteria
         return new_resource.alarm
       else
         new_resource.alarm
@@ -158,6 +158,7 @@ module RackspaceCloudMonitoringCookbook
     end
 
     # rubocop:disable MethodLength
+    # rubocop:disable Metrics/CyclomaticComplexity
     # FIXME: improve this (store default alarm criteria in a file?)
     def parsed_alarm_criteria
       return new_resource.alarm_criteria if new_resource.alarm_criteria
@@ -172,7 +173,7 @@ module RackspaceCloudMonitoringCookbook
           return new AlarmStatus(OK, 'Memory usage is below your warning threshold of #{new_resource.warning}%');
         "
       when 'agent.disk'
-        fail 'There is no relevant default alarm_criteria for agent.disk, please provide :alarm_criteria' if new_resource.alarm
+        fail 'There is no relevant default alarm_criteria for agent.disk, please provide :alarm_criteria' if new_resource.alarm && new_resource.target
       when 'agent.cpu'
         "if (metric['usage_average'] > #{new_resource.critical} ) {
             return new AlarmStatus(CRITICAL, 'CPU usage is \#{usage_average}%, above your critical threshold of #{new_resource.critical}%');
@@ -230,6 +231,7 @@ module RackspaceCloudMonitoringCookbook
         "
       end
     end
+    # rubocop:enable Metrics/CyclomaticComplexity
     # rubocop:enable MethodLength
 
     def parsed_template_from_type

--- a/test/unit/spec/rackspace_cloud_monitoring_check_centos65_spec.rb
+++ b/test/unit/spec/rackspace_cloud_monitoring_check_centos65_spec.rb
@@ -193,7 +193,20 @@ describe 'rackspace_cloud_monitoring_check_test::* on Centos 6.5' do
         expect(chef_run).to render_file('/etc/rackspace-monitoring-agent.conf.d/agent.disk.sda1.yaml').with_content('An agent.disk alarm criteria')
       end
     end
-    context 'rackspace_cloud_monitoring_check for disk without an alarm criteria' do
+    context 'rackspace_cloud_monitoring_check for disk with a target but without an alarm criteria' do
+      cached(:chef_run) do
+        ChefSpec::SoloRunner.new(CENTOS_CHECK_OPTS) do |node|
+          node_resources(node)
+          node.set['rackspace_cloud_monitoring_check_test']['type'] = 'agent.disk'
+          node.set['rackspace_cloud_monitoring_check_test']['target'] = 'fake_target'
+          node.set['rackspace_cloud_monitoring_check_test']['alarm'] = true
+        end.converge('rackspace_cloud_monitoring_check_test::default')
+      end
+      it 'raises an error' do
+        expect { chef_run }.to raise_error(RuntimeError)
+      end
+    end
+    context 'rackspace_cloud_monitoring_check for disk with target discovery and without an alarm criteria' do
       cached(:chef_run) do
         ChefSpec::SoloRunner.new(CENTOS_CHECK_OPTS) do |node|
           node_resources(node)
@@ -201,8 +214,9 @@ describe 'rackspace_cloud_monitoring_check_test::* on Centos 6.5' do
           node.set['rackspace_cloud_monitoring_check_test']['alarm'] = true
         end.converge('rackspace_cloud_monitoring_check_test::default')
       end
-      it 'raises an error' do
-        expect { chef_run }.to raise_error(RuntimeError)
+      it 'disables alarm' do
+        expect(chef_run).to_not render_file('/etc/rackspace-monitoring-agent.conf.d/agent.disk.sda1.yaml').with_content('alarms')
+        expect(chef_run).to_not render_file('/etc/rackspace-monitoring-agent.conf.d/agent.disk.sda2.yaml').with_content('alarms')
       end
     end
   end

--- a/test/unit/spec/rackspace_cloud_monitoring_check_ubuntu1204_spec.rb
+++ b/test/unit/spec/rackspace_cloud_monitoring_check_ubuntu1204_spec.rb
@@ -193,7 +193,20 @@ describe 'rackspace_cloud_monitoring_check_test::* on Ubuntu 12.04' do
         expect(chef_run).to render_file('/etc/rackspace-monitoring-agent.conf.d/agent.disk.sda1.yaml').with_content('An agent.disk alarm criteria')
       end
     end
-    context 'rackspace_cloud_monitoring_check for disk without an alarm criteria' do
+    context 'rackspace_cloud_monitoring_check for disk with a target but without an alarm criteria' do
+      cached(:chef_run) do
+        ChefSpec::SoloRunner.new(UBUNTU1204_CHECK_OPTS) do |node|
+          node_resources(node)
+          node.set['rackspace_cloud_monitoring_check_test']['type'] = 'agent.disk'
+          node.set['rackspace_cloud_monitoring_check_test']['target'] = 'fake_target'
+          node.set['rackspace_cloud_monitoring_check_test']['alarm'] = true
+        end.converge('rackspace_cloud_monitoring_check_test::default')
+      end
+      it 'raises an error' do
+        expect { chef_run }.to raise_error(RuntimeError)
+      end
+    end
+    context 'rackspace_cloud_monitoring_check for disk with target discovery and without an alarm criteria' do
       cached(:chef_run) do
         ChefSpec::SoloRunner.new(UBUNTU1204_CHECK_OPTS) do |node|
           node_resources(node)
@@ -201,8 +214,9 @@ describe 'rackspace_cloud_monitoring_check_test::* on Ubuntu 12.04' do
           node.set['rackspace_cloud_monitoring_check_test']['alarm'] = true
         end.converge('rackspace_cloud_monitoring_check_test::default')
       end
-      it 'raises an error' do
-        expect { chef_run }.to raise_error(RuntimeError)
+      it 'disables alarm' do
+        expect(chef_run).to_not render_file('/etc/rackspace-monitoring-agent.conf.d/agent.disk.sda1.yaml').with_content('alarms')
+        expect(chef_run).to_not render_file('/etc/rackspace-monitoring-agent.conf.d/agent.disk.sda5.yaml').with_content('alarms')
       end
     end
   end

--- a/test/unit/spec/rackspace_cloud_monitoring_check_ubuntu1404_spec.rb
+++ b/test/unit/spec/rackspace_cloud_monitoring_check_ubuntu1404_spec.rb
@@ -192,7 +192,20 @@ describe 'rackspace_cloud_monitoring_check_test::* on Ubuntu 14.04' do
         expect(chef_run).to render_file('/etc/rackspace-monitoring-agent.conf.d/agent.disk.vda.yaml').with_content('An agent.disk alarm criteria')
       end
     end
-    context 'rackspace_cloud_monitoring_check for disk without an alarm criteria' do
+    context 'rackspace_cloud_monitoring_check for disk with a target but without an alarm criteria' do
+      cached(:chef_run) do
+        ChefSpec::SoloRunner.new(UBUNTU1404_CHECK_OPTS) do |node|
+          node_resources(node)
+          node.set['rackspace_cloud_monitoring_check_test']['type'] = 'agent.disk'
+          node.set['rackspace_cloud_monitoring_check_test']['target'] = 'fake_target'
+          node.set['rackspace_cloud_monitoring_check_test']['alarm'] = true
+        end.converge('rackspace_cloud_monitoring_check_test::default')
+      end
+      it 'raises an error' do
+        expect { chef_run }.to raise_error(RuntimeError)
+      end
+    end
+    context 'rackspace_cloud_monitoring_check for disk with target discovery and without an alarm criteria' do
       cached(:chef_run) do
         ChefSpec::SoloRunner.new(UBUNTU1404_CHECK_OPTS) do |node|
           node_resources(node)
@@ -200,8 +213,8 @@ describe 'rackspace_cloud_monitoring_check_test::* on Ubuntu 14.04' do
           node.set['rackspace_cloud_monitoring_check_test']['alarm'] = true
         end.converge('rackspace_cloud_monitoring_check_test::default')
       end
-      it 'raises an error' do
-        expect { chef_run }.to raise_error(RuntimeError)
+      it 'disables alarm' do
+        expect(chef_run).to_not render_file('/etc/rackspace-monitoring-agent.conf.d/agent.disk.vda.yaml').with_content('alarms')
       end
     end
   end


### PR DESCRIPTION
A test context was missing, therefore I didn't notice even when using auto-target it was raising an error ( the expected behaviour was to disable alarm)
