### PR TITLE
Circle ci

### DIFF
--- a/.kitchen.cloud.yml
+++ b/.kitchen.cloud.yml
@@ -1,0 +1,8 @@
+---
+driver:
+  name: rackspace
+  flavor_id: performance1-2
+  rackspace_region: IAD
+  require_chef_omnibus: latest
+  server_name: ci-<%= ENV['CIRCLE_PROJECT_REPONAME'] %>-<%= ENV['CIRCLE_BUILD_NUM'] %>
+  wait_for: 1200

--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,7 @@ end
 group :unit do
   gem 'berkshelf', '~> 3'
   gem 'chefspec'
+  gem 'chef', '= 12.0.3'
 end
 
 group :kitchen_common do

--- a/Rakefile
+++ b/Rakefile
@@ -12,8 +12,8 @@ namespace :style do
   desc 'Run Chef style checks'
   FoodCritic::Rake::LintTask.new(:chef) do |t|
     t.options = { search_gems: true,
-                  fail_tags: %w(correctness rackspace),
-                  chef_version: '11.6.0'
+                  tags: %w(~rackspace-support),
+                  fail_tags: %w(correctness,rackspace)
                 }
   end
 end
@@ -23,31 +23,46 @@ task style: ['style:chef', 'style:ruby']
 
 # Rspec and ChefSpec
 desc 'Run ChefSpec unit tests'
-RSpec::Core::RakeTask.new(:spec) do |t, _args|
+RSpec::Core::RakeTask.new(:spec) do |t|
   t.rspec_opts = 'test/unit'
 end
 
-# Integration tests. Kitchen.ci
+# Integration tests - kitchen.ci
+desc 'Run Test Kitchen'
 namespace :integration do
-  desc 'Run Test Kitchen with Vagrant'
+  Kitchen.logger = Kitchen.default_file_logger
+
+  desc 'Run kitchen test with Vagrant'
   task :vagrant do
-    Kitchen.logger = Kitchen.default_file_logger
     Kitchen::Config.new.instances.each do |instance|
       instance.test(:always)
     end
   end
 
-  desc 'Run Test Kitchen with cloud plugins'
-  task :cloud do
-    if ENV['CI'] == 'true'
-      Kitchen.logger = Kitchen.default_file_logger
-      @loader = Kitchen::Loader::YAML.new(local_config: '/var/lib/jenkins/.kitchen/config.yml')
-      config = Kitchen::Config.new(loader: @loader)
-      config.instances.each do |instance|
-        instance.test(:always)
+  %w(verify destroy).each do |t|
+    desc "Run kitchen #{t} with cloud plugins"
+    namespace :cloud do
+      task t do
+        @loader = Kitchen::Loader::YAML.new(local_config: '.kitchen.cloud.yml')
+        config = Kitchen::Config.new(loader: @loader)
+        concurrency = config.instances.size
+        queue = Queue.new
+        config.instances.each { |i| queue << i }
+        concurrency.times { queue << nil }
+        threads = []
+        concurrency.times do
+          threads << Thread.new do
+            while instance = queue.pop
+              instance.send(t)
+            end
+          end
+        end
+        threads.map(&:join)
       end
     end
   end
+
+  task cloud: ['cloud:verify', 'cloud:destroy']
 end
 
 desc 'Run all tests on CI Platform'

--- a/Thorfile
+++ b/Thorfile
@@ -1,0 +1,12 @@
+# encoding: utf-8
+
+require 'bundler'
+require 'bundler/setup'
+require 'berkshelf/thor'
+
+begin
+  require 'kitchen/thor_tasks'
+  Kitchen::ThorTasks.new
+rescue LoadError
+  puts '>>>>> Kitchen gem not loaded, omitting tasks' unless ENV['CI']
+end

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,25 @@
+machine:
+  ruby:
+    version: 2.1.5
+  environment:
+    KITCHEN_LOCAL_YAML: .kitchen.cloud.yml
+
+dependencies:
+  cache_directories:
+    - "~/bundle"
+  pre:
+    - ssh-keygen -y -f ~/.ssh/build_key.rsa > ~/.ssh/id_rsa.pub
+  override:
+    - bundle install --path=~/bundle --jobs=4 --retry=3:
+        timeout: 600
+
+test:
+  override:
+    - bundle exec rake style:
+        timeout: 120
+    - bundle exec rake spec:
+        timeout: 120
+    - bundle exec rake integration:cloud:verify:
+        timeout: 600
+  post:
+    - bundle exec rake integration:cloud:destroy


### PR DESCRIPTION
Adding dependencies so CircleCi can pass.

Somehow something change in Chef 12.1.0 preventing the test about raising exception to pass. which is why I've done 1e15658.

I tried to reproduce the issue on a clean repo but it doesn't work, I'm wondering if somehow now Chef intercepts exception from LWRP and return an error instead ( I was not using LWRP when trying to reproduce the issue) : 

with Chef 12.0.3 : 

```
[2015-03-17T11:29:39+00:00] DEBUG: Platform ubuntu version 14.04 found
[2015-03-17T11:29:39+00:00] INFO: Running queued delayed notifications before re-raising exception
```

With Chef 12.1.0 : 

```
[2015-03-17T11:22:53+00:00] INFO: Running queued delayed notifications before re-raising exception
[2015-03-17T11:22:53+00:00] ERROR: Converge failed with error message rackspace_cloud_monitoring_service[default] (rackspace_cloud_monitoring_service_test::default line 3) had an error: RuntimeError: Cloud credential api_key missing, cannot setup cloud-monitoring (please set :cloud_credentials_api_key)
```

@martinb3 Maybe you are aware of something ?
