### PR TITLE
Some refactoring to get alarm criteria

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -17,6 +17,11 @@ LineLength:
 MethodLength:
   Max: 40
 
+# Increase allowed lines in a module.  Short modules are good, but 100 lines
+#   is a bit too low.
+ModuleLength:
+  Max: 150
+
 # Favor explicit over implicit code: don't complain of "redundant returns"
 RedundantReturn:
   Enabled: false

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -1,274 +1,256 @@
 module RackspaceCloudMonitoringCookbook
   # Helpers for the providers
   module Helpers
-    include Chef::DSL::IncludeRecipe
+    # Get the alarms criteria
+    module AlarmCriteria
+      require 'erb'
+      def template_criteria(type)
+        template = File.read("#{File.dirname(__FILE__)}/../templates/default/libraries/#{type}.erb")
+        ERB.new(template).result(binding)
+      end
 
-    def agent_conf_d
-      '/etc/rackspace-monitoring-agent.conf.d'
-    end
+      def alarm_criteria_agent_memory
+        template_criteria('agent_memory')
+      end
 
-    def create_agent_conf_d
-      directory agent_conf_d do
-        owner 'root'
-        group 'root'
-        mode 00755
+      def alarm_criteria_agent_disk
+        fail 'There is no relevant default alarm_criteria for agent.disk, please provide :alarm_criteria' if new_resource.alarm && new_resource.target
+      end
+
+      def alarm_criteria_agent_cpu
+        template_criteria('agent_cpu')
+      end
+
+      def alarm_criteria_agent_load
+        template_criteria('agent_load')
+      end
+
+      def alarm_criteria_agent_filesystem
+        template_criteria('agent_filesystem')
+      end
+
+      def alarm_criteria_agent_network
+        {
+          'recv' => template_criteria('agent_network_recv'),
+          'send' => template_criteria('agent_network_send')
+        }
+      end
+
+      def alarm_criteria_remote_http
+        template_criteria('remote_http')
       end
     end
 
-    def plugin_path
-      '/usr/lib/rackspace-monitoring-agent/plugins'
-    end
+    # Get params after they've been processed/filtered
+    module ParsedParams
+      include RackspaceCloudMonitoringCookbook::Helpers::AlarmCriteria
 
-    def configure_package_repositories
-      if %w(rhel fedora).include? node['platform_family']
-        yum_repository 'monitoring' do
-          description 'Rackspace Cloud Monitoring agent repo'
-          baseurl "https://stable.packages.cloudmonitoring.rackspace.com/#{node['platform']}-#{node['platform_version'][0]}-x86_64"
-          gpgkey "https://monitoring.api.rackspacecloud.com/pki/agent/#{node['platform']}-#{node['platform_version'][0]}.asc"
-          enabled true
-          gpgcheck true
-          action :add
-        end
-      else
-        apt_repository 'monitoring' do
-          uri "https://stable.packages.cloudmonitoring.rackspace.com/#{node['platform']}-#{node['lsb']['release']}-x86_64"
-          distribution 'cloudmonitoring'
-          components ['main']
-          key 'https://monitoring.api.rackspacecloud.com/pki/agent/linux.asc'
-          action :add
-        end
+      def parsed_label
+        return new_resource.label if new_resource.label
+        "Check for #{new_resource.type}"
       end
-    end
 
-    def parsed_label
-      return new_resource.label if new_resource.label
-      "Check for #{new_resource.type}"
-    end
-
-    def parsed_cloud_credentials_username
-      return new_resource.cloud_credentials_username if new_resource.cloud_credentials_username
-      fail 'Cloud credential username missing, cannot setup cloud-monitoring (please set :cloud_credentials_username)'
-    end
-
-    def parsed_cloud_credentials_api_key
-      return new_resource.cloud_credentials_api_key if new_resource.cloud_credentials_api_key
-      fail 'Cloud credential api_key missing, cannot setup cloud-monitoring (please set :cloud_credentials_api_key)'
-    end
-
-    def parsed_target_hostname
-      return new_resource.target_hostname if new_resource.target_hostname
-      node['cloud']['public_ipv4']
-    end
-
-    def parsed_target
-      return new_resource.target.split if new_resource.target
-      case new_resource.type
-      when 'agent.disk'
-        Chef::Log.warn("No target specified for #{new_resource.type}, disabling alarm(as there is not default) and looking for target...")
-        target_disk
-      when 'agent.filesystem'
-        Chef::Log.warn("No target specified for #{new_resource.type}, looking for target...")
-        target_filesystem
-      when 'agent.network'
-        Chef::Log.warn("No target specified for #{new_resource.type}, looking for target...")
-        target_network
+      def parsed_cloud_credentials_username
+        return new_resource.cloud_credentials_username if new_resource.cloud_credentials_username
+        fail 'Cloud credential username missing, cannot setup cloud-monitoring (please set :cloud_credentials_username)'
       end
-    end
 
-    def target_filesystem
-      target = []
-      excluded_fs = %(tmpfs devtmpfs devpts proc mqueue cgroup efivars sysfs sys securityfs configfs fusectl pstore)
-      unless node['filesystem'].nil?
-        node['filesystem'].each do |key, data|
-          next if data['percent_used'].nil? || data['fs_type'].nil?
-          next if excluded_fs.include?(data['fs_type'])
-          Chef::Log.warn("Found filesystem : #{data['mount']}")
-          target << data['mount']
+      def parsed_cloud_credentials_api_key
+        return new_resource.cloud_credentials_api_key if new_resource.cloud_credentials_api_key
+        fail 'Cloud credential api_key missing, cannot setup cloud-monitoring (please set :cloud_credentials_api_key)'
+      end
+
+      def parsed_target_hostname
+        return new_resource.target_hostname if new_resource.target_hostname
+        node['cloud']['public_ipv4']
+      end
+
+      def parsed_target
+        return new_resource.target.split if new_resource.target
+        case new_resource.type
+        when 'agent.disk'
+          Chef::Log.warn("No target specified for #{new_resource.type}, disabling alarm(as there is not default) and looking for target...")
+          target_disk
+        when 'agent.filesystem'
+          Chef::Log.warn("No target specified for #{new_resource.type}, looking for target...")
+          target_filesystem
+        when 'agent.network'
+          Chef::Log.warn("No target specified for #{new_resource.type}, looking for target...")
+          target_network
         end
       end
-      target
-    end
 
-    def target_disk
-      target = []
-      node['filesystem'].each do |key, data|
-        if key =~ %r{^/dev/(sd|vd|xvd|hd)[a-z]}
-          Chef::Log.warn("Found disk : #{key}")
-          target << key
+      def parsed_alarm
+        case new_resource.type
+        # Disable alarm for agent_disk if not target was specified
+        when 'agent.disk'
+          return false unless new_resource.alarm_criteria
+          return new_resource.alarm
+        else
+          new_resource.alarm
         end
       end
-      target
-    end
 
-    def target_network
-      Chef::Log.warn("Found default interface : #{node['network']['default_interface']}")
-      node['network']['default_interface'].split
-    end
+      def parsed_send_warning
+        return new_resource.send_warning if new_resource.send_warning
+        fail "You must define :send_warning for #{new_resource.type} if you enabled alarm" if new_resource.type == 'agent.network' && new_resource.alarm
+      end
 
-    def parsed_alarm
-      case new_resource.type
-      # Disable alarm for agent_disk if not target was specified
-      when 'agent.disk'
-        return false unless new_resource.alarm_criteria
-        return new_resource.alarm
-      else
-        new_resource.alarm
+      def parsed_send_critical
+        return new_resource.send_critical if new_resource.send_critical
+        fail "You must define :send_critical for #{new_resource.type} if you enabled alarm" if new_resource.type == 'agent.network' && new_resource.alarm
+      end
+
+      def parsed_recv_warning
+        return new_resource.recv_warning if new_resource.recv_warning
+        fail "You must define :recv_warning for #{new_resource.type} if you enabled alarm" if new_resource.type == 'agent.network' && new_resource.alarm
+      end
+
+      def parsed_recv_critical
+        return new_resource.recv_critical if new_resource.recv_critical
+        fail "You must define :recv_critical for #{new_resource.type} if you enabled alarm" if new_resource.type == 'agent.network' && new_resource.alarm
+      end
+
+      # Get filename from URI if not defined
+      def parsed_plugin_filename
+        return new_resource.plugin_filename if new_resource.plugin_filename
+        if new_resource.plugin_url && new_resource.type == 'agent.plugin'
+          File.basename(URI(new_resource.plugin_url).request_uri)
+        elsif new_resource.type == 'agent.plugin'
+          fail "You must specify at least a :plugin_filename for #{new_resource.name}"
+        end
+      end
+
+      def parsed_alarm_criteria
+        return new_resource.alarm_criteria if new_resource.alarm_criteria
+        supported_alarm_criteria = %w( agent.memory agent.cpu agent.load agent.filesystem agent.disk agent.network remote.http)
+        send('alarm_criteria_' + new_resource.type.gsub('.', '_')) if supported_alarm_criteria.include?(new_resource.type)
+      end
+
+      def parsed_template_from_type
+        return new_resource.template if new_resource.template
+        if %w( agent.memory agent.cpu agent.load agent.filesystem agent.disk agent.network remote.http agent.plugin).include?(new_resource.type)
+          "#{new_resource.type}.conf.erb"
+        else
+          Chef::Log.info("Using custom monitor for #{new_resource.type}")
+          'agent.custom.conf.erb'
+        end
+      end
+
+      def parsed_template_variables(disabled)
+        {
+          cookbook: new_resource.cookbook,
+          label: parsed_label,
+          disabled: disabled,
+          type: new_resource.type,
+          alarm: parsed_alarm,
+          alarm_criteria: parsed_alarm_criteria,
+          period: new_resource.period,
+          timeout: new_resource.timeout,
+          critical: new_resource.critical,
+          warning: new_resource.warning,
+          notification_plan_id: new_resource.notification_plan_id,
+          target: parsed_target,
+          target_hostname: parsed_target_hostname,
+          send_warning: parsed_send_warning,
+          send_critical: parsed_send_critical,
+          recv_warning: parsed_recv_warning,
+          recv_critical: parsed_recv_critical,
+          plugin_filename: parsed_plugin_filename,
+          # Using inspect so it dumps a string representing an array
+          plugin_args: new_resource.plugin_args.inspect,
+          plugin_timeout: new_resource.plugin_timeout,
+          variables: new_resource.variables
+        }
       end
     end
 
-    def sanitize_target(target, type)
-      case type
-      when 'agent.disk'
-        ::File.basename(target)
-      when 'agent.filesystem'
-        ::File.basename(target).gsub('/', 'slash')
-      when 'agent.network'
+    # Static path
+    module StaticParams
+      def agent_conf_d
+        '/etc/rackspace-monitoring-agent.conf.d'
+      end
+
+      def plugin_path
+        '/usr/lib/rackspace-monitoring-agent/plugins'
+      end
+    end
+
+    # Any other helpers (mainly Chef resources)
+    module Other
+      include Chef::DSL::IncludeRecipe
+      include RackspaceCloudMonitoringCookbook::Helpers::ParsedParams
+      include RackspaceCloudMonitoringCookbook::Helpers::StaticParams
+
+      def create_agent_conf_d
+        directory agent_conf_d do
+          owner 'root'
+          group 'root'
+          mode 00755
+        end
+      end
+
+      def configure_package_repositories
+        if %w(rhel fedora).include? node['platform_family']
+          yum_repository 'monitoring' do
+            description 'Rackspace Cloud Monitoring agent repo'
+            baseurl "https://stable.packages.cloudmonitoring.rackspace.com/#{node['platform']}-#{node['platform_version'][0]}-x86_64"
+            gpgkey "https://monitoring.api.rackspacecloud.com/pki/agent/#{node['platform']}-#{node['platform_version'][0]}.asc"
+            enabled true
+            gpgcheck true
+            action :add
+          end
+        else
+          apt_repository 'monitoring' do
+            uri "https://stable.packages.cloudmonitoring.rackspace.com/#{node['platform']}-#{node['lsb']['release']}-x86_64"
+            distribution 'cloudmonitoring'
+            components ['main']
+            key 'https://monitoring.api.rackspacecloud.com/pki/agent/linux.asc'
+            action :add
+          end
+        end
+      end
+
+      def target_filesystem
+        target = []
+        excluded_fs = %(tmpfs devtmpfs devpts proc mqueue cgroup efivars sysfs sys securityfs configfs fusectl pstore)
+        unless node['filesystem'].nil?
+          node['filesystem'].each do |key, data|
+            next if data['percent_used'].nil? || data['fs_type'].nil?
+            next if excluded_fs.include?(data['fs_type'])
+            Chef::Log.warn("Found filesystem : #{data['mount']}")
+            target << data['mount']
+          end
+        end
         target
       end
-    end
 
-    def parsed_send_warning
-      return new_resource.send_warning if new_resource.send_warning
-      fail "You must define :send_warning for #{new_resource.type} if you enabled alarm" if new_resource.type == 'agent.network' && new_resource.alarm
-    end
-
-    def parsed_send_critical
-      return new_resource.send_critical if new_resource.send_critical
-      fail "You must define :send_critical for #{new_resource.type} if you enabled alarm" if new_resource.type == 'agent.network' && new_resource.alarm
-    end
-
-    def parsed_recv_warning
-      return new_resource.recv_warning if new_resource.recv_warning
-      fail "You must define :recv_warning for #{new_resource.type} if you enabled alarm" if new_resource.type == 'agent.network' && new_resource.alarm
-    end
-
-    def parsed_recv_critical
-      return new_resource.recv_critical if new_resource.recv_critical
-      fail "You must define :recv_critical for #{new_resource.type} if you enabled alarm" if new_resource.type == 'agent.network' && new_resource.alarm
-    end
-
-    # Get filename from URI if not defined
-    def parsed_plugin_filename
-      return new_resource.plugin_filename if new_resource.plugin_filename
-      if new_resource.plugin_url && new_resource.type == 'agent.plugin'
-        File.basename(URI(new_resource.plugin_url).request_uri)
-      elsif new_resource.type == 'agent.plugin'
-        fail "You must specify at least a :plugin_filename for #{new_resource.name}"
+      def target_disk
+        target = []
+        node['filesystem'].each do |key, data|
+          if key =~ %r{^/dev/(sd|vd|xvd|hd)[a-z]}
+            Chef::Log.warn("Found disk : #{key}")
+            target << key
+          end
+        end
+        target
       end
-    end
 
-    # rubocop:disable MethodLength
-    # rubocop:disable Metrics/CyclomaticComplexity
-    # FIXME: improve this (store default alarm criteria in a file?)
-    def parsed_alarm_criteria
-      return new_resource.alarm_criteria if new_resource.alarm_criteria
-      case new_resource.type
-      when 'agent.memory'
-        "if (percentage(metric['actual_used'], metric['total']) > #{new_resource.critical} ) {
-            return new AlarmStatus(CRITICAL, 'Memory usage is above your critical threshold of #{new_resource.critical}%');
-          }
-          if (percentage(metric['actual_used'], metric['total']) > #{new_resource.warning} ) {
-            return new AlarmStatus(WARNING, 'Memory usage is above your warning threshold of #{new_resource.warning}%');
-          }
-          return new AlarmStatus(OK, 'Memory usage is below your warning threshold of #{new_resource.warning}%');
-        "
-      when 'agent.disk'
-        fail 'There is no relevant default alarm_criteria for agent.disk, please provide :alarm_criteria' if new_resource.alarm && new_resource.target
-      when 'agent.cpu'
-        "if (metric['usage_average'] > #{new_resource.critical} ) {
-            return new AlarmStatus(CRITICAL, 'CPU usage is \#{usage_average}%, above your critical threshold of #{new_resource.critical}%');
-          }
-          if (metric['usage_average'] > #{new_resource.warning} ) {
-            return new AlarmStatus(WARNING, 'CPU usage is \#{usage_average}%, above your warning threshold of #{new_resource.warning}%');
-          }
-          return new AlarmStatus(OK, 'CPU usage is \#{usage_average}%, below your warning threshold of #{new_resource.warning}%');
-       "
-      when 'agent.load'
-        "if (metric['5m'] > #{new_resource.critical} ) {
-            return new AlarmStatus(CRITICAL, '5 minute load average is \#{5m}, above your critical threshold of #{new_resource.critical}');
-          }
-          if (metric['5m'] > #{new_resource.warning} ) {
-            return new AlarmStatus(WARNING, '5 minute load average is \#{5m}, above your warning threshold of #{new_resource.warning}');
-          }
-          return new AlarmStatus(OK, '5 minute load average is \#{5m}, below your warning threshold of #{new_resource.warning}');
-        "
-      when 'agent.filesystem'
-        "if (percentage(metric['used'], metric['total']) > #{new_resource.critical} ) {
-              return new AlarmStatus(CRITICAL, 'Disk usage is above #{new_resource.critical}%, \#{used} out of \#{total}');
-          }
-          if (percentage(metric['used'], metric['total']) > #{new_resource.warning} ) {
-              return new AlarmStatus(WARNING, 'Disk usage is above #{new_resource.warning}%, \#{used} out of \#{total}');
-          }
-          return new AlarmStatus(OK, 'Disk usage is below your warning threshold of #{new_resource.warning}%, \#{used} out of \#{total}');
-        "
-      when 'agent.network'
-        {
-          'recv' =>
-            "if (rate(metric['rx_bytes']) > #{parsed_recv_critical} ) {
-            return new AlarmStatus(CRITICAL, 'Network receive rate is above your critical threshold of #{parsed_recv_critical}B/s');
-          }
-          if (rate(metric['rx_bytes']) > #{parsed_recv_warning} ) {
-            return new AlarmStatus(WARNING, 'Network receive rate is above your warning threshold of #{parsed_recv_warning}B/s');
-          }
-          return new AlarmStatus(OK, 'Network receive rate is below your warning threshold of #{parsed_recv_warning}B/s');",
-          'send' =>
-            "if (rate(metric['tx_bytes']) > #{parsed_send_critical}) {
-            return new AlarmStatus(CRITICAL, 'Network transmit rate is above your critical threshold of #{parsed_send_critical}B/s');
-          }
-          if (rate(metric['tx_bytes']) > #{parsed_send_warning}) {
-            return new AlarmStatus(WARNING, 'Network transmit rate is above your warning threshold of #{parsed_send_warning}B/s');
-          }
-          return new AlarmStatus(OK, 'Network transmit rate is below your warning threshold of #{parsed_send_warning}B/s');"
-        }
-      when 'remote.http'
-        "if (metric['code'] regex '4[0-9][0-9]') {
-           return new AlarmStatus(CRITICAL, 'HTTP server responding with 4xx status');
-         }
-         if (metric['code'] regex '5[0-9][0-9]') {
-           return new AlarmStatus(CRITICAL, 'HTTP server responding with 5xx status');
-         }
-         return new AlarmStatus(OK, 'HTTP server is functioning normally');
-        "
+      def target_network
+        Chef::Log.warn("Found default interface : #{node['network']['default_interface']}")
+        node['network']['default_interface'].split
       end
-    end
-    # rubocop:enable Metrics/CyclomaticComplexity
-    # rubocop:enable MethodLength
 
-    def parsed_template_from_type
-      return new_resource.template if new_resource.template
-      if %w( agent.memory agent.cpu agent.load agent.filesystem agent.disk agent.network remote.http agent.plugin).include?(new_resource.type)
-        "#{new_resource.type}.conf.erb"
-      else
-        Chef::Log.info("Using custom monitor for #{new_resource.type}")
-        'agent.custom.conf.erb'
+      def sanitize_target(target, type)
+        case type
+        when 'agent.disk'
+          ::File.basename(target)
+        when 'agent.filesystem'
+          ::File.basename(target).gsub('/', 'slash')
+        when 'agent.network'
+          target
+        end
       end
-    end
-
-    def parsed_template_variables(disabled)
-      {
-        cookbook: new_resource.cookbook,
-        label: parsed_label,
-        disabled: disabled,
-        type: new_resource.type,
-        alarm: parsed_alarm,
-        alarm_criteria: parsed_alarm_criteria,
-        period: new_resource.period,
-        timeout: new_resource.timeout,
-        critical: new_resource.critical,
-        warning: new_resource.warning,
-        notification_plan_id: new_resource.notification_plan_id,
-        target: parsed_target,
-        target_hostname: parsed_target_hostname,
-        send_warning: parsed_send_warning,
-        send_critical: parsed_send_critical,
-        recv_warning: parsed_recv_warning,
-        recv_critical: parsed_recv_critical,
-        plugin_filename: parsed_plugin_filename,
-        # Using inspect so it dumps a string representing an array
-        plugin_args: new_resource.plugin_args.inspect,
-        plugin_timeout: new_resource.plugin_timeout,
-        variables: new_resource.variables
-      }
     end
   end
 end

--- a/libraries/provider_rackspace_cloud_monitoring_check.rb
+++ b/libraries/provider_rackspace_cloud_monitoring_check.rb
@@ -4,7 +4,7 @@ class Chef
   class Provider
     # Provider definition for rackspace_cloud_monitoring_check
     class RackspaceCloudMonitoringCheck < Chef::Provider::LWRPBase
-      include RackspaceCloudMonitoringCookbook::Helpers
+      include RackspaceCloudMonitoringCookbook::Helpers::Other
 
       use_inline_resources if defined?(use_inline_resources)
 

--- a/libraries/provider_rackspace_cloud_monitoring_service.rb
+++ b/libraries/provider_rackspace_cloud_monitoring_service.rb
@@ -4,7 +4,7 @@ class Chef
   class Provider
     # Provider definition for rackspace_cloud_monitoring_service
     class RackspaceCloudMonitoringService < Chef::Provider::LWRPBase
-      include RackspaceCloudMonitoringCookbook::Helpers
+      include RackspaceCloudMonitoringCookbook::Helpers::Other
 
       use_inline_resources if defined?(use_inline_resources)
 

--- a/templates/default/agent.cpu.conf.erb
+++ b/templates/default/agent.cpu.conf.erb
@@ -13,5 +13,5 @@ alarms:
         label: CPU Usage
         notification_plan_id: <%= @notification_plan_id %>
         criteria: |
-          <%= @alarm_criteria %>
+<%= @alarm_criteria %>
 <% end %>

--- a/templates/default/agent.custom.conf.erb
+++ b/templates/default/agent.custom.conf.erb
@@ -13,5 +13,5 @@ alarms:
     label: <%= @type %> Usage
         notification_plan_id: <%= @notification_plan_id %>
         criteria: |
-          <%= @alarm_criteria %>
+<%= @alarm_criteria %>
 <% end %>

--- a/templates/default/agent.disk.conf.erb
+++ b/templates/default/agent.disk.conf.erb
@@ -15,6 +15,6 @@ alarms:
         label: usage on <%= @target %>
         notification_plan_id: <%= @notification_plan_id %>
         criteria: |
-          <%= @alarm_criteria %>
+<%= @alarm_criteria %>
 <% end %>
 

--- a/templates/default/agent.filesystem.conf.erb
+++ b/templates/default/agent.filesystem.conf.erb
@@ -15,5 +15,5 @@ alarms:
         label: usage on <%= @target %>
         notification_plan_id: <%= @notification_plan_id %>
         criteria: |
-          <%= @alarm_criteria %>
+<%= @alarm_criteria %>
 <% end %>

--- a/templates/default/agent.load.conf.erb
+++ b/templates/default/agent.load.conf.erb
@@ -13,5 +13,5 @@ alarms:
         label: High Load Average
         notification_plan_id: <%= @notification_plan_id %>
         criteria: |
-          <%= @alarm_criteria %>
+<%= @alarm_criteria %>
 <% end %>

--- a/templates/default/agent.memory.conf.erb
+++ b/templates/default/agent.memory.conf.erb
@@ -13,5 +13,5 @@ alarms:
         label: Memory Usage
         notification_plan_id: <%= @notification_plan_id %>
         criteria: |
-          <%= @alarm_criteria %>
+<%= @alarm_criteria %>
 <% end %>

--- a/templates/default/agent.network.conf.erb
+++ b/templates/default/agent.network.conf.erb
@@ -15,11 +15,11 @@ alarms:
         label: Network receive rate on <%= @target %>
         notification_plan_id: <%= @notification_plan_id %>
         criteria: |
-          <%= @alarm_criteria['recv'] %>
+<%= @alarm_criteria['recv'] %>
     alarm-network-transmit:
         label: Network transmit rate on <%= @target %>
         notification_plan_id: <%= @notification_plan_id %>
         criteria: |
-          <%= @alarm_criteria['send'] %>
+<%= @alarm_criteria['send'] %>
 <% end %>
 

--- a/templates/default/agent.plugin.conf.erb
+++ b/templates/default/agent.plugin.conf.erb
@@ -20,5 +20,5 @@ alarms:
     label: Check from <%= @plugin_filename %>
     notification_plan_id: <%= @notification_plan_id %>
     criteria: |
-      <%= @alarm_criteria %>
+<%= @alarm_criteria %>
 <% end %>

--- a/templates/default/libraries/agent_cpu.erb
+++ b/templates/default/libraries/agent_cpu.erb
@@ -1,0 +1,8 @@
+        "if (metric['usage_average'] > <%= new_resource.critical %> ) {
+            return new AlarmStatus(CRITICAL, 'CPU usage is #{usage_average}%, above your critical threshold of <%= new_resource.critical %>%');
+          }
+          if (metric['usage_average'] > <%= new_resource.warning %> ) {
+            return new AlarmStatus(WARNING, 'CPU usage is #{usage_average}%, above your warning threshold of <%= new_resource.warning %>%');
+          }
+            return new AlarmStatus(OK, 'CPU usage is #{usage_average}%, below your warning threshold of <%= new_resource.warning %>%');
+       "

--- a/templates/default/libraries/agent_cpu.erb
+++ b/templates/default/libraries/agent_cpu.erb
@@ -1,8 +1,7 @@
-        "if (metric['usage_average'] > <%= new_resource.critical %> ) {
+          if (metric['usage_average'] > <%= new_resource.critical %> ) {
             return new AlarmStatus(CRITICAL, 'CPU usage is #{usage_average}%, above your critical threshold of <%= new_resource.critical %>%');
           }
           if (metric['usage_average'] > <%= new_resource.warning %> ) {
             return new AlarmStatus(WARNING, 'CPU usage is #{usage_average}%, above your warning threshold of <%= new_resource.warning %>%');
           }
             return new AlarmStatus(OK, 'CPU usage is #{usage_average}%, below your warning threshold of <%= new_resource.warning %>%');
-       "

--- a/templates/default/libraries/agent_filesystem.erb
+++ b/templates/default/libraries/agent_filesystem.erb
@@ -1,8 +1,7 @@
-        "if (percentage(metric['used'], metric['total']) > <%= new_resource.critical %> ) {
+          if (percentage(metric['used'], metric['total']) > <%= new_resource.critical %> ) {
               return new AlarmStatus(CRITICAL, 'Disk usage is above <%= new_resource.critical %>%, #{used} out of #{total}');
           }
           if (percentage(metric['used'], metric['total']) > <%= new_resource.warning %> ) {
               return new AlarmStatus(WARNING, 'Disk usage is above <%= new_resource.warning %>%, #{used} out of #{total}');
           }
           return new AlarmStatus(OK, 'Disk usage is below your warning threshold of <%= new_resource.warning %>%, #{used} out of #{total}');
-        "

--- a/templates/default/libraries/agent_filesystem.erb
+++ b/templates/default/libraries/agent_filesystem.erb
@@ -1,0 +1,8 @@
+        "if (percentage(metric['used'], metric['total']) > <%= new_resource.critical %> ) {
+              return new AlarmStatus(CRITICAL, 'Disk usage is above <%= new_resource.critical %>%, #{used} out of #{total}');
+          }
+          if (percentage(metric['used'], metric['total']) > <%= new_resource.warning %> ) {
+              return new AlarmStatus(WARNING, 'Disk usage is above <%= new_resource.warning %>%, #{used} out of #{total}');
+          }
+          return new AlarmStatus(OK, 'Disk usage is below your warning threshold of <%= new_resource.warning %>%, #{used} out of #{total}');
+        "

--- a/templates/default/libraries/agent_load.erb
+++ b/templates/default/libraries/agent_load.erb
@@ -1,0 +1,8 @@
+        "if (metric['5m'] > <%= new_resource.critical %> ) {
+            return new AlarmStatus(CRITICAL, '5 minute load average is #{5m}, above your critical threshold of <%= new_resource.critical %>');
+          }
+          if (metric['5m'] > <%= new_resource.warning %> ) {
+            return new AlarmStatus(WARNING, '5 minute load average is #{5m}, above your warning threshold of <%= new_resource.warning %>');
+          }
+          return new AlarmStatus(OK, '5 minute load average is #{5m}, below your warning threshold of <%= new_resource.warning %>');
+        "

--- a/templates/default/libraries/agent_load.erb
+++ b/templates/default/libraries/agent_load.erb
@@ -1,8 +1,7 @@
-        "if (metric['5m'] > <%= new_resource.critical %> ) {
+          if (metric['5m'] > <%= new_resource.critical %> ) {
             return new AlarmStatus(CRITICAL, '5 minute load average is #{5m}, above your critical threshold of <%= new_resource.critical %>');
           }
           if (metric['5m'] > <%= new_resource.warning %> ) {
             return new AlarmStatus(WARNING, '5 minute load average is #{5m}, above your warning threshold of <%= new_resource.warning %>');
           }
           return new AlarmStatus(OK, '5 minute load average is #{5m}, below your warning threshold of <%= new_resource.warning %>');
-        "

--- a/templates/default/libraries/agent_memory.erb
+++ b/templates/default/libraries/agent_memory.erb
@@ -1,8 +1,7 @@
-        "if (percentage(metric['actual_used'], metric['total']) > <%= new_resource.critical %> ) {
+          if (percentage(metric['actual_used'], metric['total']) > <%= new_resource.critical %> ) {
             return new AlarmStatus(CRITICAL, 'Memory usage is above your critical threshold of <%= new_resource.critical %>%');
           }
           if (percentage(metric['actual_used'], metric['total']) > <%= new_resource.warning %> )
             return new AlarmStatus(WARNING, 'Memory usage is above your warning threshold of <%= new_resource.warning %>%');
           }
             return new AlarmStatus(OK, 'Memory usage is below your warning threshold of <%= new_resource.warning %>%');
-        "

--- a/templates/default/libraries/agent_memory.erb
+++ b/templates/default/libraries/agent_memory.erb
@@ -1,0 +1,8 @@
+        "if (percentage(metric['actual_used'], metric['total']) > <%= new_resource.critical %> ) {
+            return new AlarmStatus(CRITICAL, 'Memory usage is above your critical threshold of <%= new_resource.critical %>%');
+          }
+          if (percentage(metric['actual_used'], metric['total']) > <%= new_resource.warning %> )
+            return new AlarmStatus(WARNING, 'Memory usage is above your warning threshold of <%= new_resource.warning %>%');
+          }
+            return new AlarmStatus(OK, 'Memory usage is below your warning threshold of <%= new_resource.warning %>%');
+        "

--- a/templates/default/libraries/agent_network_recv.erb
+++ b/templates/default/libraries/agent_network_recv.erb
@@ -1,0 +1,7 @@
+            "if (rate(metric['rx_bytes']) > <%= parsed_recv_critical %> ) {
+            return new AlarmStatus(CRITICAL, 'Network receive rate is above your critical threshold of <%= parsed_recv_critical %>B/s');
+          }
+          if (rate(metric['rx_bytes']) > <%= parsed_recv_warning %> ) {
+            return new AlarmStatus(WARNING, 'Network receive rate is above your warning threshold of <%= parsed_recv_warning %>B/s');
+          }
+          return new AlarmStatus(OK, 'Network receive rate is below your warning threshold of <%= parsed_recv_warning %>B/s');"

--- a/templates/default/libraries/agent_network_recv.erb
+++ b/templates/default/libraries/agent_network_recv.erb
@@ -1,7 +1,7 @@
-            "if (rate(metric['rx_bytes']) > <%= parsed_recv_critical %> ) {
+          if (rate(metric['rx_bytes']) > <%= parsed_recv_critical %> ) {
             return new AlarmStatus(CRITICAL, 'Network receive rate is above your critical threshold of <%= parsed_recv_critical %>B/s');
           }
           if (rate(metric['rx_bytes']) > <%= parsed_recv_warning %> ) {
             return new AlarmStatus(WARNING, 'Network receive rate is above your warning threshold of <%= parsed_recv_warning %>B/s');
           }
-          return new AlarmStatus(OK, 'Network receive rate is below your warning threshold of <%= parsed_recv_warning %>B/s');"
+          return new AlarmStatus(OK, 'Network receive rate is below your warning threshold of <%= parsed_recv_warning %>B/s');

--- a/templates/default/libraries/agent_network_send.erb
+++ b/templates/default/libraries/agent_network_send.erb
@@ -1,0 +1,7 @@
+            "if (rate(metric['tx_bytes']) > <%= parsed_send_critical %>) {
+            return new AlarmStatus(CRITICAL, 'Network transmit rate is above your critical threshold of <%= parsed_send_critical %>B/s');
+          }
+          if (rate(metric['tx_bytes']) > <%= parsed_send_warning %>) {
+            return new AlarmStatus(WARNING, 'Network transmit rate is above your warning threshold of <%= parsed_send_warning %>B/s');
+          }
+          return new AlarmStatus(OK, 'Network transmit rate is below your warning threshold of <%= parsed_send_warning %>B/s');"

--- a/templates/default/libraries/agent_network_send.erb
+++ b/templates/default/libraries/agent_network_send.erb
@@ -1,7 +1,7 @@
-            "if (rate(metric['tx_bytes']) > <%= parsed_send_critical %>) {
+          if (rate(metric['tx_bytes']) > <%= parsed_send_critical %>) {
             return new AlarmStatus(CRITICAL, 'Network transmit rate is above your critical threshold of <%= parsed_send_critical %>B/s');
           }
           if (rate(metric['tx_bytes']) > <%= parsed_send_warning %>) {
             return new AlarmStatus(WARNING, 'Network transmit rate is above your warning threshold of <%= parsed_send_warning %>B/s');
           }
-          return new AlarmStatus(OK, 'Network transmit rate is below your warning threshold of <%= parsed_send_warning %>B/s');"
+          return new AlarmStatus(OK, 'Network transmit rate is below your warning threshold of <%= parsed_send_warning %>B/s');

--- a/templates/default/libraries/remote_http.erb
+++ b/templates/default/libraries/remote_http.erb
@@ -1,0 +1,8 @@
+        "if (metric['code'] regex '4[0-9][0-9]') {
+           return new AlarmStatus(CRITICAL, 'HTTP server responding with 4xx status');
+         }
+         if (metric['code'] regex '5[0-9][0-9]') {
+           return new AlarmStatus(CRITICAL, 'HTTP server responding with 5xx status');
+         }
+         return new AlarmStatus(OK, 'HTTP server is functioning normally');
+        "

--- a/templates/default/libraries/remote_http.erb
+++ b/templates/default/libraries/remote_http.erb
@@ -1,8 +1,7 @@
-        "if (metric['code'] regex '4[0-9][0-9]') {
+         if (metric['code'] regex '4[0-9][0-9]') {
            return new AlarmStatus(CRITICAL, 'HTTP server responding with 4xx status');
          }
          if (metric['code'] regex '5[0-9][0-9]') {
            return new AlarmStatus(CRITICAL, 'HTTP server responding with 5xx status');
          }
          return new AlarmStatus(OK, 'HTTP server is functioning normally');
-        "

--- a/templates/default/remote.http.conf.erb
+++ b/templates/default/remote.http.conf.erb
@@ -23,5 +23,5 @@ alarms:
     label: Remote HTTP check on <%= @target_hostname %>
     notification_plan_id: npTechnicalContactsEmail
     criteria: |
-      <%= @alarm_criteria %>
+<%= @alarm_criteria %>
 <% end %>

--- a/test/fixtures/cookbooks/rackspace_cloud_monitoring_check_test/recipes/disk.rb
+++ b/test/fixtures/cookbooks/rackspace_cloud_monitoring_check_test/recipes/disk.rb
@@ -5,5 +5,5 @@ rackspace_cloud_monitoring_check 'agent.disk' do
   target '/dev/xda1'
   alarm true
   action :create
-  alarm_criteria 'fake_criteria'
+  alarm_criteria '          fake_criteria'
 end

--- a/test/integration/default/serverspec/default_spec.rb
+++ b/test/integration/default/serverspec/default_spec.rb
@@ -1,4 +1,5 @@
 # Encoding: utf-8
+require 'yaml'
 
 require_relative 'spec_helper'
 
@@ -26,5 +27,12 @@ check_files.each do |check|
   # Minimal test as content is tested in Chefspecs
   describe file("/etc/rackspace-monitoring-agent.conf.d/#{check}.yaml") do
     it { should be_file }
+  end
+
+  # Useful as rackspace_agent will fails to create metrics otherwise
+  describe 'Yaml syntax is correct' do
+    it "passes syntax for #{check}.yaml" do
+      expect { YAML.load_file("/etc/rackspace-monitoring-agent.conf.d/#{check}.yaml") }.to_not raise_error
+    end
   end
 end


### PR DESCRIPTION
It should solve #17, and make it a bit more tidy
- split helper modules in submodules (more easier to read, better for rubocop)
- use templates to change default alarm criteria
- increase a bit module lengh limit in rubocop as we need a lot of method in our modules
